### PR TITLE
Add supplier management page

### DIFF
--- a/static/js/suppliers.js
+++ b/static/js/suppliers.js
@@ -183,4 +183,4 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // 初始載入
     loadSuppliers();
-});
+})

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,9 @@
                     <a href="/members" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-blue-700">
                         <i class="fas fa-users mr-1"></i> 會員管理
                     </a>
+                    <a href="/suppliers" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-blue-700">
+                        <i class="fas fa-truck mr-1"></i> 供應商管理
+                    </a>
                     <a href="/reports" class="px-3 py-2 rounded-md text-sm font-medium hover:bg-blue-700">
                         <i class="fas fa-chart-bar mr-1"></i> 報表分析
                     </a>
@@ -59,6 +62,9 @@
             </a>
             <a href="/members" class="block px-3 py-2 rounded-md text-base font-medium hover:bg-blue-700">
                 <i class="fas fa-users mr-2"></i> 會員管理
+            </a>
+            <a href="/suppliers" class="block px-3 py-2 rounded-md text-base font-medium hover:bg-blue-700">
+                <i class="fas fa-truck mr-2"></i> 供應商管理
             </a>
             <a href="/reports" class="block px-3 py-2 rounded-md text-base font-medium hover:bg-blue-700">
                 <i class="fas fa-chart-bar mr-2"></i> 報表分析


### PR DESCRIPTION
## Summary
- implement `供應商管理` page in Streamlit app
- aggregate sales by supplier within a selected date range
- include navigation link for supplier management in HTML frontend
- fix trailing characters in `suppliers.js`

## Testing
- `python -m py_compile app.py main.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_688204714b348327afa68ca8701dbe29