### PR TITLE
Add simple reports demo

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Any
 import json
 from datetime import datetime
 import os
+from services.report_service import ReportService
 import logging
 
 # 配置日誌
@@ -148,6 +149,15 @@ async def members_page(request: Request):
     return templates.TemplateResponse("members.html", {
         "request": request,
         "title": "會員管理"
+    })
+
+# 報表分析頁面
+@app.get("/reports", response_class=HTMLResponse)
+async def reports_page(request: Request):
+    """顯示簡易報表分析介面"""
+    return templates.TemplateResponse("reports.html", {
+        "request": request,
+        "title": "報表分析"
     })
 
 # 商品相關 API
@@ -617,8 +627,16 @@ async def delete_supplier(supplier_id: str):
     # 刪除供應商
     updated_suppliers = [s for s in suppliers if s["id"] != supplier_id]
     save_data("suppliers", updated_suppliers)
-    
+
     return {"message": "供應商已刪除", "id": supplier_id}
+
+# 報表相關 API
+@app.get("/api/reports/overview")
+async def get_report_overview(start_date: str = None, end_date: str = None):
+    """返回簡易銷售報表數據"""
+    service = ReportService(str(DATA_DIR))
+    report = service.get_sales_report(start_date, end_date)
+    return report
 
 
 # 啟動服務

--- a/static/js/reports.js
+++ b/static/js/reports.js
@@ -1,0 +1,77 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const topProductsBody = document.getElementById('topProductsBody');
+
+    const loadReport = async () => {
+        window.app.ui.showLoading('載入報表資料...');
+        try {
+            const res = await fetch('/api/reports/overview');
+            if (!res.ok) throw new Error('load failed');
+            const data = await res.json();
+            renderCharts(data);
+            renderTopProducts(data.top_products);
+        } catch (err) {
+            console.error(err);
+            window.app.ui.showNotification('error', '載入報表失敗');
+        } finally {
+            window.app.ui.hideLoading();
+        }
+    };
+
+    const renderCharts = (data) => {
+        const dailyLabels = Object.keys(data.daily_sales || {});
+        const dailyValues = Object.values(data.daily_sales || {});
+        const ctxDaily = document.getElementById('dailySalesChart').getContext('2d');
+        new Chart(ctxDaily, {
+            type: 'line',
+            data: {
+                labels: dailyLabels,
+                datasets: [{
+                    label: '銷售額',
+                    data: dailyValues,
+                    backgroundColor: 'rgba(59,130,246,0.1)',
+                    borderColor: 'rgb(59,130,246)',
+                    tension: 0.3,
+                    fill: true
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true } }
+            }
+        });
+
+        const categoryLabels = Object.keys(data.category_sales || {});
+        const categoryValues = Object.values(data.category_sales || {});
+        const ctxCategory = document.getElementById('categorySalesChart').getContext('2d');
+        new Chart(ctxCategory, {
+            type: 'doughnut',
+            data: {
+                labels: categoryLabels,
+                datasets: [{
+                    data: categoryValues,
+                    backgroundColor: [
+                        '#60a5fa','#34d399','#fbbf24','#f87171','#a78bfa','#f472b6'
+                    ]
+                }]
+            },
+            options: { responsive: true, maintainAspectRatio: false }
+        });
+    };
+
+    const renderTopProducts = (products) => {
+        if (!products || products.length === 0) {
+            topProductsBody.innerHTML = '<tr><td colspan="2" class="text-center py-4">無資料</td></tr>';
+            return;
+        }
+        topProductsBody.innerHTML = products.map(p => `
+            <tr>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">${p.name}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">$${p.amount}</td>
+            </tr>
+        `).join('');
+    };
+
+    loadReport();
+});

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="bg-white shadow rounded-lg p-6">
+    <h1 class="text-2xl font-bold text-gray-800 mb-6">報表分析</h1>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="bg-white p-4 rounded shadow">
+            <h2 class="text-lg font-semibold mb-2">每日銷售額</h2>
+            <canvas id="dailySalesChart" class="h-64"></canvas>
+        </div>
+        <div class="bg-white p-4 rounded shadow">
+            <h2 class="text-lg font-semibold mb-2">分類銷售額</h2>
+            <canvas id="categorySalesChart" class="h-64"></canvas>
+        </div>
+    </div>
+
+    <div class="mt-6 bg-white p-4 rounded shadow">
+        <h2 class="text-lg font-semibold mb-2">熱銷商品</h2>
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead>
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">商品</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">銷售額</th>
+                </tr>
+            </thead>
+            <tbody id="topProductsBody" class="bg-white divide-y divide-gray-200">
+                <tr><td colspan="2" class="text-center py-4">載入中...</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/reports.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add reports page template for basic charts
- create reports JavaScript to fetch data and render charts
- expose `/reports` page and `/api/reports/overview` endpoint

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6882092dd27883279af19fc20989d9eb