### PR TITLE
feat: implement full product management page

### DIFF
--- a/static/js/products.js
+++ b/static/js/products.js
@@ -1,207 +1,303 @@
+// static/js/products.js - 完整商品管理功能
 
-let allProducts = []; // 用於儲存所有商品資料
+document.addEventListener('DOMContentLoaded', () => {
+    // DOM 元素
+    const addProductBtn = document.getElementById('addProductBtn');
+    const productModal = document.getElementById('productModal');
+    const modalTitle = document.getElementById('modalTitle');
+    const productForm = document.getElementById('productForm');
+    const saveProductBtn = document.getElementById('saveProductBtn');
+    const cancelProductBtn = document.getElementById('cancelProductBtn');
+    const productsTableBody = document.getElementById('productsTableBody');
 
-// DOM 元素
-const productImageInput = document.getElementById('productImage');
-const imagePreview = document.getElementById('imagePreview');
-const barcodeInput = document.getElementById('barcode');
+    // 篩選元素
+    const searchInput = document.getElementById('searchInput');
+    const categoryFilter = document.getElementById('categoryFilter');
+    const statusFilter = document.getElementById('statusFilter');
 
-/**
- * 根據搜尋文字、分類與庫存狀態過濾商品，並重新渲染表格。
- */
-const filterAndRender = () => {
-    const searchText = searchInput.value.trim().toLowerCase();
-    const category = categoryFilter.value;
-    const status = statusFilter.value;
-    const filtered = allProducts.filter(p => {
-        const nameMatch = (p.name || '').toLowerCase().includes(searchText);
-        const barcodeMatch = (p.barcode || '').toLowerCase().includes(searchText);
-        const matchSearch = nameMatch || barcodeMatch;
-        const matchCategory = category === '' || p.category === category;
-        const stock = parseInt(p.stock, 10) || 0;
-        const min = parseInt(p.minStock, 10) || 5;
-        let statusMatch = true;
-        if (status === 'instock') statusMatch = stock > min;
-        if (status === 'low')     statusMatch = stock > 0 && stock <= min;
-        if (status === 'out')     statusMatch = stock <= 0;
-        return matchSearch && matchCategory && statusMatch;
-    });
-    renderTable(filtered);
-};
+    // 表單內元素
+    const productImageInput = document.getElementById('productImage');
+    const imagePreview = document.getElementById('imagePreview');
+    const barcodeInput = document.getElementById('barcode');
+    const supplierSelect = document.getElementById('supplier');
 
-// 註冊搜尋與篩選事件，當輸入或選取變更時自動過濾
-searchInput.addEventListener('input', filterAndRender);
-categoryFilter.addEventListener('change', filterAndRender);
-statusFilter.addEventListener('change', filterAndRender);
+    let allProducts = [];
+    let suppliers = [];
 
-// 呼叫 API 新增商品
-const createProduct = async (formData) => {
-    const res = await fetch('/api/products', {
-        method: 'POST',
-        body: formData // Send FormData directly
-    });
-    if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || '新增商品失敗');
-    }
-    return res.json();
-};
+    /** 顯示商品 Modal */
+    const showModal = (isEdit = false, product = null) => {
+        productForm.reset();
+        document.getElementById('productId').value = '';
 
-// 呼叫 API 更新商品
-const updateProductApi = async (id, formData) => {
-    const res = await fetch(`/api/products/${id}`, {
-        method: 'PUT',
-        body: formData // Send FormData directly
-    });
-    if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || '更新商品失敗');
-    }
-    return res.json();
-};
-
-// 呼叫 API 刪除商品
-const deleteProductApi = async (id) => {
-    const res = await fetch(`/api/products/${id}`, { method: 'DELETE' });
-    if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || '刪除商品失敗');
-    }
-};
-
-// 處理表單提交
-const handleFormSubmit = async () => {
-    const productId = document.getElementById('productId').value;
-    const isEdit = !!productId;
-
-    const formData = new FormData();
-    formData.append('name', document.getElementById('productName').value);
-    formData.append('barcode', document.getElementById('barcode').value);
-    formData.append('category', document.getElementById('category').value);
-    formData.append('supplier_id', document.getElementById('supplier').value);
-    formData.append('purchase_price', document.getElementById('costPrice').value);
-    formData.append('sale_price', document.getElementById('salePrice').value);
-    formData.append('stock', document.getElementById('stock').value);
-    formData.append('min_stock', document.getElementById('minStock').value);
-    formData.append('unit', document.getElementById('unit').value);
-    formData.append('description', document.getElementById('description').value);
-
-    if (productImageInput.files[0]) {
-        formData.append('image', productImageInput.files[0]);
-    }
-
-    window.app.ui.showLoading('儲存中...');
-    try {
-        if (isEdit) {
-            await updateProductApi(productId, formData);
-            window.app.ui.showNotification('success', '商品已更新');
+        if (isEdit && product) {
+            modalTitle.textContent = '編輯商品';
+            document.getElementById('productId').value = product.id;
+            document.getElementById('productName').value = product.name || '';
+            document.getElementById('barcode').value = product.barcode || '';
+            document.getElementById('category').value = product.category || '';
+            document.getElementById('supplier').value = product.supplier_id || '';
+            document.getElementById('costPrice').value = product.purchase_price || 0;
+            document.getElementById('salePrice').value = product.sale_price || 0;
+            document.getElementById('stock').value = product.stock || 0;
+            document.getElementById('minStock').value = product.min_stock || product.minStock || 5;
+            document.getElementById('unit').value = product.unit || '';
+            document.getElementById('description').value = product.description || '';
+            imagePreview.src = product.image || 'https://via.placeholder.com/150';
         } else {
-            await createProduct(formData);
-            window.app.ui.showNotification('success', '商品已新增');
+            modalTitle.textContent = '新增商品';
+            imagePreview.src = 'https://via.placeholder.com/150';
         }
-        await loadProducts();
-    } catch (error) {
-        console.error('儲存失敗:', error);
-        window.app.ui.showNotification('error', error.message);
-    } finally {
-        window.app.ui.hideLoading();
-        closeModal();
-    }
-};
 
-const handleTableClick = (e) => {
-    const target = e.target;
-    const row = target.closest('tr');
-    const productId = row.dataset.id;
+        productModal.classList.remove('hidden');
+        document.body.classList.add('overflow-hidden');
+    };
 
-    if (target.closest('.delete-btn')) {
-        window.app.ui.showConfirmDialog({
-            title: '確認刪除',
-            message: `您確定要刪除商品 #${productId} 嗎？此操作無法復原。`,
-            confirmText: '確認刪除',
-        }).then(async (confirmed) => {
-            if (confirmed) {
-                window.app.ui.showLoading('刪除中...');
-                try {
-                    await deleteProductApi(productId);
-                    window.app.ui.showNotification('success', '商品已刪除');
-                    await loadProducts();
-                } catch (error) {
-                    console.error('刪除失敗:', error);
-                    window.app.ui.showNotification('error', error.message);
-                } finally {
-                    window.app.ui.hideLoading();
-                }
+    /** 關閉商品 Modal */
+    const closeModal = () => {
+        productModal.classList.add('hidden');
+        document.body.classList.remove('overflow-hidden');
+    };
+
+    /** 載入供應商列表 */
+    const loadSuppliers = async () => {
+        try {
+            const res = await fetch('/api/suppliers');
+            if (res.ok) {
+                suppliers = await res.json();
+                supplierSelect.innerHTML = '<option value="">選擇供應商</option>' +
+                    suppliers.map(s => `<option value="${s.id}">${s.name}</option>`).join('');
             }
+        } catch (err) {
+            console.warn('載入供應商失敗', err);
+        }
+    };
+
+    /** 從 API 載入商品 */
+    const loadProducts = async () => {
+        window.app.ui.showLoading('載入商品中...');
+        try {
+            const res = await fetch('/api/products');
+            if (!res.ok) throw new Error('無法獲取商品列表');
+            allProducts = await res.json();
+            filterAndRender();
+        } catch (error) {
+            console.error('載入商品失敗:', error);
+            window.app.ui.showNotification('error', '載入商品失敗');
+        } finally {
+            window.app.ui.hideLoading();
+        }
+    };
+
+    /** 渲染商品表格 */
+    const renderTable = (products) => {
+        if (products.length === 0) {
+            productsTableBody.innerHTML = `<tr><td colspan="8" class="text-center py-4">沒有商品資料</td></tr>`;
+            return;
+        }
+
+        productsTableBody.innerHTML = products.map(product => {
+            const stock = parseInt(product.stock, 10) || 0;
+            const min = parseInt(product.min_stock || product.minStock || 5, 10);
+            let statusBadge;
+            if (stock <= 0) {
+                statusBadge = '無庫存';
+            } else if (stock <= min) {
+                statusBadge = '低庫存';
+            } else {
+                statusBadge = '庫存正常';
+            }
+            return `
+                <tr data-id="${product.id}">
+                    <td>${product.name}</td>
+                    <td>${product.barcode || '-'}</td>
+                    <td>${product.category || '-'}</td>
+                    <td>${product.purchase_price || 0}</td>
+                    <td>${product.sale_price || 0}</td>
+                    <td>${stock}</td>
+                    <td>${statusBadge}</td>
+                    <td class="text-right text-sm font-medium">
+                        <button class="edit-btn text-blue-600 hover:underline">編輯</button>
+                        <button class="delete-btn text-red-600 hover:underline ml-4">刪除</button>
+                    </td>
+                </tr>`;
+        }).join('');
+    };
+
+    /** 依搜尋與篩選條件顯示 */
+    const filterAndRender = () => {
+        const searchText = searchInput.value.trim().toLowerCase();
+        const category = categoryFilter.value;
+        const status = statusFilter.value;
+        const filtered = allProducts.filter(p => {
+            const nameMatch = (p.name || '').toLowerCase().includes(searchText);
+            const barcodeMatch = (p.barcode || '').toLowerCase().includes(searchText);
+            const matchSearch = nameMatch || barcodeMatch;
+            const matchCategory = !category || p.category === category;
+            const stock = parseInt(p.stock, 10) || 0;
+            const min = parseInt(p.min_stock || p.minStock || 5, 10);
+            let statusMatch = true;
+            if (status === 'in_stock') statusMatch = stock > min;
+            if (status === 'low_stock') statusMatch = stock > 0 && stock <= min;
+            if (status === 'out_of_stock') statusMatch = stock <= 0;
+            return matchSearch && matchCategory && statusMatch;
         });
-    }
-};
+        renderTable(filtered);
+    };
 
-const renderTable = (products) => {
-    productsTableBody.innerHTML = products.map(product => {
-        const stock = parseInt(product.stock, 10) || 0;
-        const minStock = parseInt(product.minStock, 10) || 5;
-        let statusBadge;
+    searchInput.addEventListener('input', filterAndRender);
+    categoryFilter.addEventListener('change', filterAndRender);
+    statusFilter.addEventListener('change', filterAndRender);
 
-        if (stock <= 0) {
-            statusBadge = `無庫存`;
-        } else if (stock <= minStock) {
-            statusBadge = `低庫存`;
-        } else {
-            statusBadge = `庫存正常`;
+    /** API：新增商品 */
+    const createProduct = async (productData) => {
+        const res = await fetch('/api/products', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(productData)
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.detail || '新增商品失敗');
         }
+        return res.json();
+    };
 
-        return `
-            <tr data-id="${product.id}">
-                <td>${product.name}</td>
-                <td>${product.barcode || '-'}</td>
-                <td>${product.category || '-'}</td>
-                <td>${product.purchase_price || 0}</td>
-                <td>${product.sale_price || 0}</td>
-                <td>${stock}</td>
-                <td>${statusBadge}</td>
-                <td><button class="edit-btn text-blue-600 hover:underline">編輯</button></td>
-                <td><button class="delete-btn text-red-600 hover:underline">刪除</button></td>
-            </tr>
-        `;
-    }).join('');
-};
+    /** API：更新商品 */
+    const updateProductApi = async (id, productData) => {
+        const res = await fetch(`/api/products/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(productData)
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.detail || '更新商品失敗');
+        }
+        return res.json();
+    };
 
-// Image preview handler
-productImageInput.addEventListener('change', (event) => {
-    const file = event.target.files[0];
-    if (file) {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-            imagePreview.src = e.target.result;
+    /** API：刪除商品 */
+    const deleteProductApi = async (id) => {
+        const res = await fetch(`/api/products/${id}`, { method: 'DELETE' });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.detail || '刪除商品失敗');
+        }
+    };
+
+    /** 處理表單提交 */
+    const handleFormSubmit = async () => {
+        const productId = document.getElementById('productId').value;
+        const isEdit = !!productId;
+        const formData = new FormData(productForm);
+        const productData = {
+            name: formData.get('productName').trim(),
+            barcode: formData.get('barcode').trim(),
+            category: formData.get('category'),
+            supplier_id: formData.get('supplier'),
+            purchase_price: parseFloat(formData.get('costPrice')) || 0,
+            sale_price: parseFloat(formData.get('salePrice')) || 0,
+            stock: parseInt(formData.get('stock'), 10) || 0,
+            min_stock: parseInt(formData.get('minStock'), 10) || 0,
+            unit: formData.get('unit').trim(),
+            description: formData.get('description').trim(),
         };
-        reader.readAsDataURL(file);
-    } else {
-        imagePreview.src = 'https://via.placeholder.com/150'; // Default placeholder
-    }
-});
 
-// Barcode scanning simulation (listen for rapid input)
-let barcodeBuffer = '';
-let lastKeyTime = 0;
-const SCAN_INTERVAL = 100; // milliseconds
-
-barcodeInput.addEventListener('keydown', (e) => {
-    const currentTime = new Date().getTime();
-    if (currentTime - lastKeyTime > SCAN_INTERVAL) {
-        barcodeBuffer = ''; // Reset buffer if pause is too long
-    }
-    if (e.key === 'Enter') {
-        e.preventDefault(); // Prevent form submission
-        if (barcodeBuffer) {
-            console.log('Scanned Barcode:', barcodeBuffer);
-            // Here you would typically trigger a product lookup or other action
-            // For now, we just log it.
-            barcodeInput.value = barcodeBuffer; // Set the input value to the scanned barcode
+        window.app.ui.showLoading('儲存中...');
+        try {
+            if (isEdit) {
+                await updateProductApi(productId, productData);
+                window.app.ui.showNotification('success', '商品已更新');
+            } else {
+                await createProduct(productData);
+                window.app.ui.showNotification('success', '商品已新增');
+            }
+            await loadProducts();
+            closeModal();
+        } catch (error) {
+            console.error('儲存失敗:', error);
+            window.app.ui.showNotification('error', error.message);
+        } finally {
+            window.app.ui.hideLoading();
         }
-        barcodeBuffer = ''; // Clear buffer after processing
-    } else if (e.key.length === 1) { // Only append single character keys
-        barcodeBuffer += e.key;
-    }
-    lastKeyTime = currentTime;
+    };
+
+    /** 處理表格中的點擊 (編輯/刪除) */
+    const handleTableClick = (e) => {
+        const target = e.target;
+        const row = target.closest('tr');
+        if (!row) return;
+        const productId = row.dataset.id;
+        const product = allProducts.find(p => p.id === productId);
+
+        if (target.closest('.edit-btn')) {
+            if (product) showModal(true, product);
+        }
+
+        if (target.closest('.delete-btn')) {
+            window.app.ui.showConfirmDialog({
+                title: '確認刪除',
+                message: `您確定要刪除商品 #${productId} 嗎？此操作無法復原。`,
+                confirmText: '確認刪除',
+            }).then(async (confirmed) => {
+                if (confirmed) {
+                    window.app.ui.showLoading('刪除中...');
+                    try {
+                        await deleteProductApi(productId);
+                        window.app.ui.showNotification('success', '商品已刪除');
+                        await loadProducts();
+                    } catch (error) {
+                        console.error('刪除失敗:', error);
+                        window.app.ui.showNotification('error', error.message);
+                    } finally {
+                        window.app.ui.hideLoading();
+                    }
+                }
+            });
+        }
+    };
+
+    // 事件監聽器
+    addProductBtn.addEventListener('click', () => showModal());
+    cancelProductBtn.addEventListener('click', closeModal);
+    saveProductBtn.addEventListener('click', handleFormSubmit);
+    productsTableBody.addEventListener('click', handleTableClick);
+
+    // 圖片預覽
+    productImageInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => { imagePreview.src = e.target.result; };
+            reader.readAsDataURL(file);
+        } else {
+            imagePreview.src = 'https://via.placeholder.com/150';
+        }
+    });
+
+    // 條碼掃描模擬
+    let barcodeBuffer = '';
+    let lastKeyTime = 0;
+    const SCAN_INTERVAL = 100;
+    barcodeInput.addEventListener('keydown', (e) => {
+        const currentTime = Date.now();
+        if (currentTime - lastKeyTime > SCAN_INTERVAL) {
+            barcodeBuffer = '';
+        }
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            if (barcodeBuffer) {
+                barcodeInput.value = barcodeBuffer;
+            }
+            barcodeBuffer = '';
+        } else if (e.key.length === 1) {
+            barcodeBuffer += e.key;
+        }
+        lastKeyTime = currentTime;
+    });
+
+    // 初始化
+    loadSuppliers();
+    loadProducts();
 });
+


### PR DESCRIPTION
## Summary
- rewrite products.js to fully manage products
- load supplier options and product list via API
- add search/filtering and CRUD actions with notifications

## Testing
- `pytest` *(fails: jinja2 must be installed)*
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement jinja2)*

------
https://chatgpt.com/codex/tasks/task_e_68906b77a5cc8327bd5e2c9f260addfc