### PR TITLE
Remove barcode scanning and image upload

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -1,7 +1,6 @@
 [
   {
     "name": "原子習慣",
-    "barcode": "9789861755267",
     "category": "書籍",
     "purchase_price": 280,
     "sale_price": 350,
@@ -13,7 +12,6 @@
   {
     "id": "P002",
     "name": "被討厭的勇氣",
-    "barcode": "9789861342483",
     "category": "心理勵志",
     "purchase_price": 220,
     "sale_price": 280,
@@ -25,7 +23,6 @@
   {
     "id": "P101",
     "name": "筆記本",
-    "barcode": "4711234567890",
     "category": "文具",
     "purchase_price": 15,
     "sale_price": 25,
@@ -37,7 +34,6 @@
   {
     "id": "P102",
     "name": "原子筆",
-    "barcode": "4711234567906",
     "category": "文具",
     "purchase_price": 8,
     "sale_price": 15,
@@ -49,7 +45,6 @@
   {
     "id": "P201",
     "name": "高級鋼筆",
-    "barcode": "4711234567913",
     "category": "文具",
     "purchase_price": 900,
     "sale_price": 1200,
@@ -61,7 +56,6 @@
   {
     "id": "P301",
     "name": "高級書架",
-    "barcode": "4711234567920",
     "category": "傢俱",
     "purchase_price": 2000,
     "sale_price": 2500,
@@ -73,7 +67,6 @@
   {
     "id": "P401",
     "name": "暢銷小說",
-    "barcode": "9789573328888",
     "category": "小說",
     "purchase_price": 140,
     "sale_price": 180,
@@ -85,7 +78,6 @@
   {
     "id": "P402",
     "name": "商業理財書",
-    "barcode": "9789863441234",
     "category": "商業",
     "purchase_price": 180,
     "sale_price": 220,
@@ -97,7 +89,6 @@
   {
     "id": "P403",
     "name": "兒童繪本",
-    "barcode": "9789577623456",
     "category": "兒童",
     "purchase_price": 120,
     "sale_price": 150,

--- a/docs/data/products.json
+++ b/docs/data/products.json
@@ -1,7 +1,6 @@
 [
   {
     "name": "原子習慣",
-    "barcode": "9789861755267",
     "category": "書籍",
     "purchase_price": 280,
     "sale_price": 350,
@@ -13,7 +12,6 @@
   {
     "id": "P002",
     "name": "被討厭的勇氣",
-    "barcode": "9789861342483",
     "category": "心理勵志",
     "purchase_price": 220,
     "sale_price": 280,
@@ -25,7 +23,6 @@
   {
     "id": "P101",
     "name": "筆記本",
-    "barcode": "4711234567890",
     "category": "文具",
     "purchase_price": 15,
     "sale_price": 25,
@@ -37,7 +34,6 @@
   {
     "id": "P102",
     "name": "原子筆",
-    "barcode": "4711234567906",
     "category": "文具",
     "purchase_price": 8,
     "sale_price": 15,
@@ -49,7 +45,6 @@
   {
     "id": "P201",
     "name": "高級鋼筆",
-    "barcode": "4711234567913",
     "category": "文具",
     "purchase_price": 900,
     "sale_price": 1200,
@@ -61,7 +56,6 @@
   {
     "id": "P301",
     "name": "高級書架",
-    "barcode": "4711234567920",
     "category": "傢俱",
     "purchase_price": 2000,
     "sale_price": 2500,
@@ -73,7 +67,6 @@
   {
     "id": "P401",
     "name": "暢銷小說",
-    "barcode": "9789573328888",
     "category": "小說",
     "purchase_price": 140,
     "sale_price": 180,
@@ -85,7 +78,6 @@
   {
     "id": "P402",
     "name": "商業理財書",
-    "barcode": "9789863441234",
     "category": "商業",
     "purchase_price": 180,
     "sale_price": 220,
@@ -97,7 +89,6 @@
   {
     "id": "P403",
     "name": "兒童繪本",
-    "barcode": "9789577623456",
     "category": "兒童",
     "purchase_price": 120,
     "sale_price": 150,

--- a/docs/products.html
+++ b/docs/products.html
@@ -117,7 +117,6 @@
             <thead class="bg-gray-50">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">商品名稱</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">條碼</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">類別</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">成本價</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">售價</th>
@@ -129,7 +128,7 @@
             <tbody id="productsTableBody" class="bg-white divide-y divide-gray-200">
                 <!-- 商品數據將通過 JavaScript 動態加載 -->
                 <tr>
-                    <td colspan="8" class="px-6 py-4 text-center text-gray-500">
+                    <td colspan="7" class="px-6 py-4 text-center text-gray-500">
                         載入中...
                     </td>
                 </tr>
@@ -198,15 +197,6 @@
                                             <input type="text" name="productName" id="productName" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                         </div>
                                     </div>
-                                    <div class="sm:col-span-2">
-                                        <label for="barcode" class="block text-sm font-medium text-gray-700">條碼</label>
-                                        <div class="mt-1 flex rounded-md shadow-sm">
-                                            <input type="text" name="barcode" id="barcode" class="focus:ring-blue-500 focus:border-blue-500 flex-1 block w-full rounded-md sm:text-sm border-gray-300">
-                                            <button type="button" class="ml-3 inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                                                <i class="fas fa-barcode mr-1"></i> 掃描
-                                            </button>
-                                        </div>
-                                    </div>
                                     <div class="sm:col-span-3">
                                         <label for="category" class="block text-sm font-medium text-gray-700">類別</label>
                                         <div class="mt-1">
@@ -268,24 +258,6 @@
                                         <label for="description" class="block text-sm font-medium text-gray-700">商品描述</label>
                                         <div class="mt-1">
                                             <textarea id="description" name="description" rows="3" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"></textarea>
-                                        </div>
-                                    </div>
-                                    <div class="sm:col-span-6">
-                                        <label class="block text-sm font-medium text-gray-700">商品圖片</label>
-                                        <div class="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md">
-                                            <div class="space-y-1 text-center">
-                                                <svg class="mx-auto h-12 w-12 text-gray-400" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true">
-                                                    <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                                                </svg>
-                                                <div class="flex text-sm text-gray-600">
-                                                    <label for="productImage" class="relative cursor-pointer bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500">
-                                                        <span>上傳圖片</span>
-                                                        <input id="productImage" name="productImage" type="file" class="sr-only">
-                                                    </label>
-                                                    <p class="pl-1">或拖放檔案到這裡</p>
-                                                </div>
-                                                <p class="text-xs text-gray-500">PNG, JPG, GIF 最大 10MB</p>
-                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/docs/sales.html
+++ b/docs/sales.html
@@ -240,10 +240,7 @@
                             </button>
                         </div>
                         <div class="mt-2">
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div class="bg-gray-100 p-4 rounded-lg flex items-center justify-center">
-                                    <img id="modal-product-image" src="" alt="商品圖片" class="h-48 object-contain">
-                                </div>
+                            <div class="grid grid-cols-1 gap-4">
                                 <div>
                                     <p class="text-sm text-gray-500 mb-2">商品編號: <span id="modal-product-id"></span></p>
                                     <p class="text-2xl font-bold text-gray-900 mb-2" id="modal-product-price">$0</p>

--- a/docs/static/js/products.js
+++ b/docs/static/js/products.js
@@ -26,7 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
             modalTitle.textContent = '編輯商品';
             document.getElementById('productId').value = product.id;
             document.getElementById('productName').value = product.name || '';
-            document.getElementById('barcode').value = product.barcode || '';
             document.getElementById('category').value = product.category || '';
             document.getElementById('supplier').value = product.supplier_id || '';
             // 修正：使用 product.purchase_price
@@ -71,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // 渲染商品表格
     const renderTable = (products) => {
         if (products.length === 0) {
-            productsTableBody.innerHTML = `<tr><td colspan="8" class="text-center py-4">沒有商品資料</td></tr>`;
+            productsTableBody.innerHTML = `<tr><td colspan="7" class="text-center py-4">沒有商品資料</td></tr>`;
             return;
         }
 
@@ -91,7 +90,6 @@ document.addEventListener('DOMContentLoaded', () => {
             return `
                 <tr data-id="${product.id}">
                     <td class="px-6 py-4 whitespace-nowrap">${product.name}</td>
-                    <td class="px-6 py-4 whitespace-nowrap">${product.barcode || '-'}</td>
                     <td class="px-6 py-4 whitespace-nowrap">${product.category || '-'}</td>
                     <td class="px-6 py-4 whitespace-nowrap">$${product.purchase_price || 0}</td>
                     <td class="px-6 py-4 whitespace-nowrap">$${product.sale_price || 0}</td>
@@ -114,7 +112,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const formData = new FormData(productForm);
         const productData = {
             name: formData.get('productName'),
-            barcode: formData.get('barcode'),
             category: formData.get('category'),
             purchase_price: parseFloat(formData.get('costPrice')),
             sale_price: parseFloat(formData.get('salePrice')),

--- a/main.py
+++ b/main.py
@@ -410,7 +410,6 @@ async def get_purchase(purchase_id: str):
         for item in purchase.get("items", []):
             product = next((p for p in products if str(p.get("id")) == str(item.get("product_id"))), {})
             item["product_name"] = product.get("name", "未知商品")
-            item["barcode"] = product.get("barcode", "")
         
         return {"data": purchase}
     except HTTPException:

--- a/static/js/products.js
+++ b/static/js/products.js
@@ -16,9 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const statusFilter = document.getElementById('statusFilter');
 
     // 表單內元素
-    const productImageInput = document.getElementById('productImage');
-    const imagePreview = document.getElementById('imagePreview');
-    const barcodeInput = document.getElementById('barcode');
     const supplierSelect = document.getElementById('supplier');
 
     let allProducts = [];
@@ -33,7 +30,6 @@ document.addEventListener('DOMContentLoaded', () => {
             modalTitle.textContent = '編輯商品';
             document.getElementById('productId').value = product.id;
             document.getElementById('productName').value = product.name || '';
-            document.getElementById('barcode').value = product.barcode || '';
             document.getElementById('category').value = product.category || '';
             document.getElementById('supplier').value = product.supplier_id || '';
             document.getElementById('costPrice').value = product.purchase_price || 0;
@@ -42,10 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
             document.getElementById('minStock').value = product.min_stock || product.minStock || 5;
             document.getElementById('unit').value = product.unit || '';
             document.getElementById('description').value = product.description || '';
-            imagePreview.src = product.image || 'https://via.placeholder.com/150';
         } else {
             modalTitle.textContent = '新增商品';
-            imagePreview.src = 'https://via.placeholder.com/150';
         }
 
         productModal.classList.remove('hidden');
@@ -91,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
     /** 渲染商品表格 */
     const renderTable = (products) => {
         if (products.length === 0) {
-            productsTableBody.innerHTML = `<tr><td colspan="8" class="text-center py-4">沒有商品資料</td></tr>`;
+            productsTableBody.innerHTML = `<tr><td colspan="7" class="text-center py-4">沒有商品資料</td></tr>`;
             return;
         }
 
@@ -109,7 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
             return `
                 <tr data-id="${product.id}">
                     <td>${product.name}</td>
-                    <td>${product.barcode || '-'}</td>
                     <td>${product.category || '-'}</td>
                     <td>${product.purchase_price || 0}</td>
                     <td>${product.sale_price || 0}</td>
@@ -130,8 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const status = statusFilter.value;
         const filtered = allProducts.filter(p => {
             const nameMatch = (p.name || '').toLowerCase().includes(searchText);
-            const barcodeMatch = (p.barcode || '').toLowerCase().includes(searchText);
-            const matchSearch = nameMatch || barcodeMatch;
+            const matchSearch = nameMatch;
             const matchCategory = !category || p.category === category;
             const stock = parseInt(p.stock, 10) || 0;
             const min = parseInt(p.min_stock || p.minStock || 5, 10);
@@ -192,7 +184,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const formData = new FormData(productForm);
         const productData = {
             name: formData.get('productName').trim(),
-            barcode: formData.get('barcode').trim(),
             category: formData.get('category'),
             supplier_id: formData.get('supplier'),
             purchase_price: parseFloat(formData.get('costPrice')) || 0,
@@ -262,39 +253,6 @@ document.addEventListener('DOMContentLoaded', () => {
     cancelProductBtn.addEventListener('click', closeModal);
     saveProductBtn.addEventListener('click', handleFormSubmit);
     productsTableBody.addEventListener('click', handleTableClick);
-
-    // 圖片預覽
-    productImageInput.addEventListener('change', (event) => {
-        const file = event.target.files[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onload = (e) => { imagePreview.src = e.target.result; };
-            reader.readAsDataURL(file);
-        } else {
-            imagePreview.src = 'https://via.placeholder.com/150';
-        }
-    });
-
-    // 條碼掃描模擬
-    let barcodeBuffer = '';
-    let lastKeyTime = 0;
-    const SCAN_INTERVAL = 100;
-    barcodeInput.addEventListener('keydown', (e) => {
-        const currentTime = Date.now();
-        if (currentTime - lastKeyTime > SCAN_INTERVAL) {
-            barcodeBuffer = '';
-        }
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            if (barcodeBuffer) {
-                barcodeInput.value = barcodeBuffer;
-            }
-            barcodeBuffer = '';
-        } else if (e.key.length === 1) {
-            barcodeBuffer += e.key;
-        }
-        lastKeyTime = currentTime;
-    });
 
     // 初始化
     loadSuppliers();

--- a/templates/products.html
+++ b/templates/products.html
@@ -43,7 +43,6 @@
             <thead class="bg-gray-50">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">商品名稱</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">條碼</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">類別</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">成本價</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">售價</th>
@@ -55,7 +54,7 @@
             <tbody id="productsTableBody" class="bg-white divide-y divide-gray-200">
                 <!-- 商品數據將通過 JavaScript 動態加載 -->
                 <tr>
-                    <td colspan="8" class="px-6 py-4 text-center text-gray-500">
+                    <td colspan="7" class="px-6 py-4 text-center text-gray-500">
                         載入中...
                     </td>
                 </tr>
@@ -124,15 +123,6 @@
                                             <input type="text" name="productName" id="productName" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                         </div>
                                     </div>
-                                    <div class="sm:col-span-2">
-                                        <label for="barcode" class="block text-sm font-medium text-gray-700">條碼</label>
-                                        <div class="mt-1 flex rounded-md shadow-sm">
-                                            <input type="text" name="barcode" id="barcode" class="focus:ring-blue-500 focus:border-blue-500 flex-1 block w-full rounded-md sm:text-sm border-gray-300">
-                                            <button type="button" class="ml-3 inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                                                <i class="fas fa-barcode mr-1"></i> 掃描
-                                            </button>
-                                        </div>
-                                    </div>
                                     <div class="sm:col-span-3">
                                         <label for="category" class="block text-sm font-medium text-gray-700">類別</label>
                                         <div class="mt-1">
@@ -194,18 +184,6 @@
                                         <label for="description" class="block text-sm font-medium text-gray-700">商品描述</label>
                                         <div class="mt-1">
                                             <textarea id="description" name="description" rows="3" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"></textarea>
-                                        </div>
-                                    </div>
-                                    <div class="sm:col-span-6">
-                                        <label class="block text-sm font-medium text-gray-700">商品圖片</label>
-                                        <div class="mt-1 flex items-center space-x-4">
-                                            <img id="imagePreview" src="https://via.placeholder.com/150" alt="Image preview" class="h-24 w-24 rounded-md object-cover">
-                                            <div class="flex text-sm text-gray-600">
-                                                <label for="productImage" class="relative cursor-pointer bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500">
-                                                    <span>上傳圖片</span>
-                                                    <input id="productImage" name="productImage" type="file" class="sr-only" accept="image/*">
-                                                </label>
-                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/templates/sales.html
+++ b/templates/sales.html
@@ -168,10 +168,7 @@
                             </button>
                         </div>
                         <div class="mt-2">
-                            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div class="bg-gray-100 p-4 rounded-lg flex items-center justify-center">
-                                    <img id="modal-product-image" src="" alt="商品圖片" class="h-48 object-contain">
-                                </div>
+                            <div class="grid grid-cols-1 gap-4">
                                 <div>
                                     <p class="text-sm text-gray-500 mb-2">商品編號: <span id="modal-product-id"></span></p>
                                     <p class="text-2xl font-bold text-gray-900 mb-2" id="modal-product-price">$0</p>


### PR DESCRIPTION
## Summary
- drop barcode fields from product data and backend responses
- strip barcode scan and image upload UI from product management and sales templates
- simplify product management JS to search by name only

## Testing
- `pytest` *(fails: jinja2 must be installed)*
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement jinja2)*

------
https://chatgpt.com/codex/tasks/task_e_689070654f688327a72c426b09552be7