### PR TITLE
Add sales history page and improve sales workflow

### DIFF
--- a/static/js/sales_history.js
+++ b/static/js/sales_history.js
@@ -1,0 +1,39 @@
+// static/js/sales_history.js
+
+document.addEventListener('DOMContentLoaded', function() {
+    const historyList = document.getElementById('sales-history-list');
+
+    const renderSales = (sales) => {
+        if (!historyList) return;
+        if (!sales || sales.length === 0) {
+            historyList.innerHTML = `<tr><td colspan="4" class="text-center py-4">沒有任何銷售記錄</td></tr>`;
+            return;
+        }
+        historyList.innerHTML = sales.map(sale => {
+            const amount = sale.total || sale.final_amount || 0;
+            const date = sale.created_at || sale.sale_date;
+            return `
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap">${sale.id}</td>
+                    <td class="px-6 py-4 whitespace-nowrap">${sale.member_id || '-'}</td>
+                    <td class="px-6 py-4 whitespace-nowrap">$${amount.toLocaleString()}</td>
+                    <td class="px-6 py-4 whitespace-nowrap">${date ? new Date(date).toLocaleString() : ''}</td>
+                </tr>
+            `;
+        }).join('');
+    };
+
+    const loadSales = async () => {
+        try {
+            const res = await fetch('/api/sales');
+            if (!res.ok) throw new Error('load failed');
+            const data = await res.json();
+            renderSales(data);
+        } catch (err) {
+            console.error(err);
+            historyList.innerHTML = `<tr><td colspan="4" class="text-center py-4 text-red-500">載入失敗</td></tr>`;
+        }
+    };
+
+    loadSales();
+});

--- a/templates/sales.html
+++ b/templates/sales.html
@@ -88,10 +88,10 @@
             <div class="space-y-4">
                 <!-- 會員資訊 -->
                 <div class="bg-white p-4 rounded-lg shadow">
-                    <div class="flex justify-between items-center mb-3">
-                        <h3 class="text-lg font-medium text-gray-900">會員資訊</h3>
-                        <button id="select-member" class="text-sm text-blue-600 hover:text-blue-800">選擇會員</button>
-                    </div>
+                    <h3 class="text-lg font-medium text-gray-900 mb-3">會員資訊</h3>
+                    <select id="member-select" class="w-full mb-3 border border-gray-300 rounded-md text-sm">
+                        <option value="">非會員顧客</option>
+                    </select>
                     <div id="member-info" class="text-sm text-gray-600">
                         <div class="flex items-center">
                             <div class="flex-shrink-0 h-10 w-10 rounded-full bg-gray-200 flex items-center justify-center">

--- a/templates/sales_history.html
+++ b/templates/sales_history.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}銷售記錄 - 書房記帳與營運管理系統{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-6">
+    <h1 class="text-2xl font-bold text-gray-800 mb-4">銷售記錄</h1>
+    <div class="bg-white shadow rounded-lg overflow-hidden">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">訂單編號</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">會員</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">總金額</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">日期</th>
+                    </tr>
+                </thead>
+                <tbody id="sales-history-list" class="bg-white divide-y divide-gray-200">
+                    <tr>
+                        <td colspan="4" class="px-6 py-4 text-center text-sm text-gray-500">載入中...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/sales_history.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add sales history page and endpoint
- enhance sales cart with member selection, product filtering, and reset button
- load sales records on new page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892f60d0afc8327ba972ce62431802c